### PR TITLE
Adjust README edit form template code

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,10 +75,10 @@ As a user, I can:
 ```html
 <form id="edit-ramen">
   <h4>Update the Featured Ramen</h4>
-  <label for="rating">Rating: </label>
-  <input type="number" name="rating" id="new-rating" />
-  <label for="new-comment">Comment: </label>
-  <textarea name="new-comment" id="new-comment"></textarea>
+  <label for="edit-rating">Rating: </label>
+  <input type="number" name="edit-rating" id="edit-rating" />
+  <label for="edit-comment">Comment: </label>
+  <textarea name="edit-comment" id="edit-comment"></textarea>
   <input type="submit" value="Update" />
 </form>
 ```

--- a/src/index.test.js
+++ b/src/index.test.js
@@ -208,7 +208,7 @@ describe('handleSubmit', () => {
         const ramenFormComment = document.querySelector("#new-ramen #new-comment");
         const submitButton = document.getElementById('submit-button');
 
-        main(ramenForm)
+        main()
 
         ramenFormName.value = newRamen.name;
         ramenFormRestaurant.value = newRamen.restaurant;
@@ -219,7 +219,7 @@ describe('handleSubmit', () => {
         fireEvent.click(submitButton);
 
         const ramenMenuDivAfter = document.querySelectorAll('#ramen-menu img');
-        const img = ramenMenuDivAfter[ramenMenuDivBefore.length];
+        const img = ramenMenuDivAfter[ramenMenuDivBefore.length - 1];
         img.addEventListener('click', (event) => {
             handleClick(newRamen, event);
         });

--- a/src/index.test.js
+++ b/src/index.test.js
@@ -87,7 +87,7 @@ describe('displayRamens', () => {
 
     it('should fetch all ramens and display them as <img> inside #ramen-menu', async () => {
         const ramenMenuDiv = document.getElementById('ramen-menu');
-        
+
         displayRamens();
         await new Promise(resolve => setTimeout(resolve, 0));
 
@@ -208,18 +208,27 @@ describe('handleSubmit', () => {
         const ramenFormComment = document.querySelector("#new-ramen #new-comment");
         const submitButton = document.getElementById('submit-button');
 
-        main()
-
         ramenFormName.value = newRamen.name;
         ramenFormRestaurant.value = newRamen.restaurant;
         ramenFormImage.value = newRamen.image;
         ramenFormRating.value = newRamen.rating;
         ramenFormComment.value = newRamen.comment;
 
-        fireEvent.click(submitButton);
+        fireEvent.submit(ramenForm, {
+            target: {
+                name: { value: newRamen.name },
+                restaurant: { value: newRamen.restaurant },
+                image: { value: newRamen.image },
+                rating: { value: newRamen.rating },
+                comment: { value: newRamen.comment },
+            },
+            preventDefault: vi.fn(),
+            reset: vi.fn(),
+
+        });
 
         const ramenMenuDivAfter = document.querySelectorAll('#ramen-menu img');
-        const img = ramenMenuDivAfter[ramenMenuDivBefore.length - 1];
+        const img = ramenMenuDivAfter[ramenMenuDivBefore.length];
         img.addEventListener('click', (event) => {
             handleClick(newRamen, event);
         });


### PR DESCRIPTION
The main change is for the README's edit form template code. The current version indicates ids that already exist for the new form, making them non unique.

The test file in my repo slight differed from the current version of the tests, so I pasted the most recent version from https://github.com/learn-co-curriculum/phase-1-cc-ramen-rater-v2/blob/main/src/index.test.js into my own repository.